### PR TITLE
Add deduplication logic for warnings

### DIFF
--- a/rwarnings.lua
+++ b/rwarnings.lua
@@ -47,9 +47,9 @@ local messages = {
     [5] = nil,
 }
 
-this_chunk = nil;
-this_chunk_sequences = T{ };
-last_chunk_sequences = T{ };
+local this_chunk = nil;
+local this_chunk_sequences = T{ };
+local last_chunk_sequences = T{ };
 local function is_duplicate(e)
     if (this_chunk ~= e.chunk_data) then
         this_chunk = e.chunk_data;

--- a/rwarnings.lua
+++ b/rwarnings.lua
@@ -47,6 +47,31 @@ local messages = {
     [5] = nil,
 }
 
+this_chunk = nil;
+this_chunk_sequences = T{ };
+last_chunk_sequences = T{ };
+local function is_duplicate(e)
+    if (this_chunk ~= e.chunk_data) then
+        this_chunk = e.chunk_data;
+        last_chunk_sequences = this_chunk_sequences;
+        this_chunk_sequences = T{ };
+    end
+
+    this_sequence = struct.unpack("H", e.data, 2 + 1);
+
+    if (this_chunk_sequences:contains(this_sequence)) then
+        return true;
+    end
+
+    this_chunk_sequences:append(this_sequence);
+
+    if (last_chunk_sequences:contains(this_sequence)) then
+        return true;
+    end
+
+    return false;
+end
+
 local function copy(t)
   local t2 = {}
   for k,v in pairs(t) do
@@ -92,6 +117,10 @@ end)
 
 ashita.events.register('packet_in', 'rwarnings_packet_in', function (e)
     if (e.id == 0x028) then
+        if (is_duplicate(e)) then
+            return;
+        end
+            
         local actionPacket = ParseActionPacket(e)
 
         if (IsMonster(actionPacket.UserIndex) and (actionPacket.Type == 7 or actionPacket.Type == 8)) then


### PR DESCRIPTION
This change should (and does from my testing) ignore resent battle action packets from the server and thus prevent duplicate enemy action warnings from appearing.

Every packet in a chunk has a sequence id. If the same sequence id appears in the same or previous chunk then that packet has been resent by the server and can be marked as a duplicate.